### PR TITLE
fix NPE when maxIter=1 for KCore

### DIFF
--- a/nebula-algorithm/src/main/scala/com/vesoft/nebula/algorithm/config/Configs.scala
+++ b/nebula-algorithm/src/main/scala/com/vesoft/nebula/algorithm/config/Configs.scala
@@ -356,10 +356,10 @@ object AlgoConstants {
   val LPA_RESULT_COL: String           = "lpa"
   val CC_RESULT_COL: String            = "cc"
   val SCC_RESULT_COL: String           = "scc"
-  val BETWEENNESS_RESULT_COL: String   = "betweennedss"
+  val BETWEENNESS_RESULT_COL: String   = "betweenness"
   val SHORTPATH_RESULT_COL: String     = "shortestpath"
   val DEGREE_RESULT_COL: String        = "degree"
   val INDEGREE_RESULT_COL: String      = "inDegree"
   val OUTDEGREE_RESULT_COL: String     = "outDegree"
-  val TRIANGLECOUNT_RESULT_COL: String = "tranglecount"
+  val TRIANGLECOUNT_RESULT_COL: String = "trianglecount"
 }

--- a/nebula-algorithm/src/main/scala/com/vesoft/nebula/algorithm/lib/KCoreAlgo.scala
+++ b/nebula-algorithm/src/main/scala/com/vesoft/nebula/algorithm/lib/KCoreAlgo.scala
@@ -16,7 +16,7 @@ import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 object KCoreAlgo {
   private val LOGGER = Logger.getLogger(this.getClass)
 
-  val ALGORITHM: String = "LabelPropagation"
+  val ALGORITHM: String = "KCore"
 
   /**
     * run the louvain algorithm for nebula graph
@@ -43,7 +43,7 @@ object KCoreAlgo {
     var lastVertexNum: Long    = graph.numVertices
     var currentVertexNum: Long = -1
     var isStable: Boolean      = false
-    var iterNum: Int           = 1
+    var iterNum: Int           = 0
 
     var degreeGraph = graph
       .outerJoinVertices(graph.degrees) { (vid, vd, degree) =>


### PR DESCRIPTION
调用KCoreAlgo算法时，如果传入maxIter=1，会报空指针异常。设置iterNum初始值为0。另外，ALGORITHM赋值错误，顺便修改。