### PR TITLE
1.ClusteringCoefficientAlgo参数为local时计算结果没有保留小数，所以总为0或1

### DIFF
--- a/nebula-algorithm/src/main/scala/com/vesoft/nebula/algorithm/lib/ClusteringCoefficientAlgo.scala
+++ b/nebula-algorithm/src/main/scala/com/vesoft/nebula/algorithm/lib/ClusteringCoefficientAlgo.scala
@@ -81,7 +81,7 @@ object ClusteringCoefficientAlgo {
     // compute the actual triangle count for each vertex
     val triangleNum = graph.triangleCount().vertices
     // compute the open triangle count for each vertex
-    val idealTriangleNum = graph.degrees.mapValues(degree => degree * (degree - 1) / 2)
+    val idealTriangleNum = graph.degrees.mapValues(degree => degree * (degree - 1) / 2.0)
     val result = triangleNum
       .innerJoin(idealTriangleNum) { (vid, actualCount, idealCount) =>
         {

--- a/nebula-algorithm/src/main/scala/com/vesoft/nebula/algorithm/lib/DfsAlgo.scala
+++ b/nebula-algorithm/src/main/scala/com/vesoft/nebula/algorithm/lib/DfsAlgo.scala
@@ -28,6 +28,7 @@ object DfsAlgo {
     }
     val bfsVertices = dfs(graph, dfsConfig.root, mutable.Seq.empty[VertexId])(dfsConfig.maxIter)
 
+    iterNums = 0
     val schema = StructType(List(StructField("dfs", LongType, nullable = false)))
 
     val rdd = spark.sparkContext.parallelize(bfsVertices.toSeq, 1).map(row => Row(row))


### PR DESCRIPTION
2.DFS算法中的全局变量使用完为重置为0，导致多次执行DFS后itemNum的值总是大于maxIter以致于DFS算法没有结果

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [√ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:
1.ClusteringCoefficientAlgo参数为local时计算结果没有保留小数，所以总为0或1
2.DFS算法中的全局变量使用完为重置为0，导致多次执行DFS后itemNum的值总是大于maxIter以致于DFS算法没有结果
## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


