### PR TITLE
fix the computation approach for weight between different communities

### DIFF
--- a/nebula-algorithm/src/main/scala/com/vesoft/nebula/algorithm/lib/LouvainAlgo.scala
+++ b/nebula-algorithm/src/main/scala/com/vesoft/nebula/algorithm/lib/LouvainAlgo.scala
@@ -143,7 +143,7 @@ object LouvainAlgo {
     LOGGER.info("============================== step 2 =======================")
     //get edges between different communities
     val edges = G.triplets
-      .filter(trip => trip.srcAttr.cId != trip.dstAttr.cId)
+      // .filter(trip => trip.srcAttr.cId != trip.dstAttr.cId)
       .map(trip => {
         val cid1   = trip.srcAttr.cId
         val cid2   = trip.dstAttr.cId


### PR DESCRIPTION
before we just computation the weight for links between communities, not including the weight inner of community.

According to paper of louvain, we should include the weight inner of community.
```
The second phase of the algorithm consists in building a new network whose nodes
are now the communities found during the first phase. To do so, --- the weights of the links
between the new nodes are given by the sum of the weight of the links between nodes
in the corresponding two communities [20].---  Links between nodes of the same community
lead to self-loops for this community in the new network. 
```